### PR TITLE
Add get_wait_time method for RateLimit

### DIFF
--- a/redis_rate_limit/__init__.py
+++ b/redis_rate_limit/__init__.py
@@ -89,7 +89,7 @@ class RateLimit(object):
         """
         expire = self._redis.pttl(self._rate_limit_key)
         # Fallback if key has not yet been set or TTL can't be retrieved
-        expire = expire / 1000.0 if expire > 0 else float(self._expire)
+        expire = expire / 1000.0 if expire else float(self._expire)
         if self.has_been_reached():
             return expire
         else:

--- a/redis_rate_limit/__init__.py
+++ b/redis_rate_limit/__init__.py
@@ -80,6 +80,21 @@ class RateLimit(object):
         """
         return int(self._redis.get(self._rate_limit_key) or 0)
 
+    def get_wait_time(self):
+        """
+        Returns estimated optimal wait time for subsequent requests.
+        If limit has already been reached, return wait time until it gets reset.
+
+        :return: float: wait time in seconds
+        """
+        expire = self._redis.pttl(self._rate_limit_key)
+        # Fallback if key has not yet been set or TTL can't be retrieved
+        expire = expire / 1000.0 if expire > 0 else float(self._expire)
+        if self.has_been_reached():
+            return expire
+        else:
+            return expire / (self._max_requests - self.get_usage())
+
     def has_been_reached(self):
         """
         Checks if Rate Limit has been reached.


### PR DESCRIPTION
Hi,

I propose adding a method named `get_wait_time` to the `RateLimit` class that would provide an estimate for optimal waiting time for subsequent requests sent by client. In case the limit has already been reached, this would result in a time until the limit gets reset. This would help the client in more effective requests throttling.