### PR TITLE
Removed backwards-incompatible use of fstrings

### DIFF
--- a/redis_rate_limit/__init__.py
+++ b/redis_rate_limit/__init__.py
@@ -130,11 +130,14 @@ class RateLimit(object):
         :return: integer: current usage
         """
         if increment_by > self._max_requests:
-            raise ValueError(f'increment_by {increment_by} overflows '
-                             f'max_requests of {self._max_requests}')
+            raise ValueError('increment_by {increment_by} overflows '
+                             'max_requests of {max_requests}'
+                             .format(increment_by=increment_by, 
+                                     max_requests=self._max_requests))
         elif increment_by <= 0:
-            raise ValueError(f'{increment_by} is not a valid increment, '
-                             f'should be greater than or equal to zero.')
+            raise ValueError('{increment_by} is not a valid increment, '
+                             'should be greater than or equal to zero.'
+                             .format(increment_by=increment_by))
 
         try:
             current_usage = self._redis.evalsha(


### PR DESCRIPTION
Fixes build failing for 2.7 and 3.5 after this commit: https://github.com/EvoluxBR/python-redis-rate-limit/commit/523e3155b101b11762a32040a08fbe496d6da71a