### PR TITLE
refactor: replace distutils with packaging

### DIFF
--- a/redis_rate_limit/__init__.py
+++ b/redis_rate_limit/__init__.py
@@ -3,7 +3,7 @@
 
 import functools
 from hashlib import sha1
-from distutils.version import StrictVersion
+from packaging.version import Version
 from redis.exceptions import NoScriptError
 from redis import Redis, ConnectionPool
 
@@ -159,7 +159,7 @@ class RateLimit(object):
         :return: bool
         """
         redis_version = self._redis.info()['redis_version']
-        is_supported = StrictVersion(redis_version) >= StrictVersion('2.6.0')
+        is_supported = Version(redis_version) >= Version('2.6.0')
         return bool(is_supported)
 
     def _reset(self):


### PR DESCRIPTION
The distutils version classes have been deprecated since Python 3.10 and are scheduled to be removed in Python 3.12. The recommended replacement is the packaging.version module, which provides a more modern and flexible implementation of version parsing and comparison.