### PR TITLE
remove runtime version check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 redis
-packaging


### PR DESCRIPTION
the `info` command or version check runs on every command/request, and on top of them,  it is extremely slow in our environment.
it takes up to ~30ms, where other commands are in the range of 0.xms. 


Suggesting to relying on engineer/developer to read the docs and not used on lower version redis, rather than checking this in the runtime. 